### PR TITLE
Hotfix 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Cadence bot settings:
 
     levelsPingOnLevelUp: Whether or not users should be @ mentioned on leveling up.
 
+    levelsMinLevelToMention: The minimum level a user must have before the bot sends a levelup message.
+
     musicVoteSkip: Set if you want users to vote on skipping songs (Default: false)
 
     musicVoteSkipRatio: Set the ratio required to voteskip, 0-1. (Default: 0.5)

--- a/cfg/default_cfg.json
+++ b/cfg/default_cfg.json
@@ -7,6 +7,7 @@
     "levelsMaxLevel": 100,
     "levelsExpCooldown": 60,
     "levelsPingOnLevelUp": true,
+    "levelsMinLevelToMention": 5,
     "musicVoteSkip": false,
     "musicVoteSkipRatio": 0.5,
     "musicSkipRequiresAdmin": false,

--- a/src/levels.py
+++ b/src/levels.py
@@ -88,12 +88,15 @@ class Levels(commands.Cog):
 
                     # check if user's level has gone up
                     if await getLevel(experience[userid]['experience']) > experience[userid]["level"]:
-                        experience[userid]["level"] = await getLevel(experience[userid]["experience"])
 
-                        if settings["levelsPingOnLevelUp"]:
-                            await message.channel.send(f"{message.author.mention} is now level {experience[userid]['level']}!")
-                        else:
-                            await message.channel.send(f"{message.author.user} is now level {experience[userid]['level']}")
+                        newlevel = await getLevel(experience[userid]["experience"])
+                        experience[userid]["level"] = newlevel
+
+                        if settings["levelsMinLevelToMention"] <= newlevel:
+                            if settings["levelsPingOnLevelUp"]:
+                                await message.channel.send(f"{message.author.mention} is now level {experience[userid]['level']}!")
+                            else:
+                                await message.channel.send(f"{message.author.user} is now level {experience[userid]['level']}")
 
                     await writeExperience()
                     print(f"Added xp to {message.author.name}")


### PR DESCRIPTION
Added a setting to adjust the minimum level before the bot sends a level up message. This helps prevent spam from the bot entering a server for the first time.

Updated readme